### PR TITLE
Add functionality for Banjo-Tooie

### DIFF
--- a/gzip/librarezip.h
+++ b/gzip/librarezip.h
@@ -15,7 +15,9 @@ size_t zip(uint8_t *in_file, size_t in_len, uint8_t *out_file, size_t out_cap);
 size_t unzip(uint8_t *in_file, size_t in_len, uint8_t *out_file, size_t out_cap);
 
 size_t bk_zip(uint8_t *in_file, size_t in_len, uint8_t *out_file, size_t out_cap);
+size_t bt_zip(uint8_t *in_file, size_t in_len, uint8_t *out_file, size_t out_cap);
 size_t bk_unzip(uint8_t *in_file, size_t in_len, uint8_t *out_file, size_t out_cap);
+size_t bt_unzip(uint8_t *in_file, size_t in_len, uint8_t *out_file, size_t out_cap);
 
 #ifdef __cplusplus
 }

--- a/gzip/unzip.c
+++ b/gzip/unzip.c
@@ -359,7 +359,36 @@ size_t bk_unzip(uint8_t *in_file, size_t in_len, uint8_t *out_file, size_t out_c
 	ext_header = pkzip = 0; /* for next file */
 	if(expected_len != bytes_out){
 
-		printf("expected size (%d) did not match output size (%d)", expected_len, bytes_out);
+		printf("expected size (%ld) did not match output size (%ld)", expected_len, bytes_out);
+	}
+    return bytes_out;
+}
+
+#define BT_HEADER_SIZE 2
+
+size_t bt_unzip(uint8_t *in_file, size_t in_len, uint8_t *out_file, size_t out_cap){
+	method = DEFLATED;
+
+	size_t expected_len = ((uint32_t)in_file[0] << 8) | ((uint32_t)in_file[1]);
+	expected_len *= 16;
+
+	bufs_init(in_file + BT_HEADER_SIZE, in_len - BT_HEADER_SIZE, out_file, out_cap);
+
+	updcrc(NULL, 0);           /* initialize crc */
+
+	int res = _inflate();
+
+	if (res == 3) {
+	    error("out of memory");
+	} else if (res != 0) {
+	    error("invalid compressed data--format violated");
+	}
+
+	flush_window();
+	ext_header = pkzip = 0; /* for next file */
+	if(expected_len != bytes_out){
+
+		printf("expected size (%ld) did not match output size (%ld)", expected_len, bytes_out);
 	}
     return bytes_out;
 }

--- a/gzip/zip.c
+++ b/gzip/zip.c
@@ -207,6 +207,28 @@ size_t bk_zip(uint8_t *in_file, size_t in_len, uint8_t *out_file, size_t out_cap
     return bytes_out;
 }
 
+size_t bt_zip(uint8_t *in_file, size_t in_len, uint8_t *out_file, size_t out_cap){
+    uch  flags = 0;         /* general purpose bit flags */
+    ush  attr = 0;          /* ascii/binary flag */
+    ush  deflate_flags = 0; /* pkzip -es, -en or -ex equivalent */
+    method = DEFLATED;
+    level = 9;
+
+    bufs_init(in_file, in_len, out_file, out_cap);
+    
+    put_byte(((in_len / 16) >> 8) & 0xff);
+    put_byte(((in_len / 16) >> 0) & 0xff);
+    
+    bi_init(NO_FILE);
+    ct_init(&attr, &method);
+    lm_init(level, &deflate_flags);
+    
+    (void)_deflate();
+
+    flush_outbuf();
+    return bytes_out;
+}
+
 size_t bufs_init(uint8_t *in_file, size_t in_len, uint8_t *out_file, size_t out_cap){
     in_file_buffer = in_file;
     in_file_remaining = in_len;

--- a/rust/src/rarezip.rs
+++ b/rust/src/rarezip.rs
@@ -60,21 +60,38 @@ pub mod bk{
         return out_buffer
     }
 
-    pub fn unzip(in_buffer : &[u8], full_header: bool) -> Vec<u8>{
-        if full_header {
-            assert_eq!(in_buffer[0..2],[0x11, 0x72], "in_buffer does not have bk header");
-            let expected_len = u32::from_be_bytes(in_buffer[2..6].try_into().unwrap()) as usize;
-            let out_buffer = __inflate::inflate_bytes(&in_buffer[6..]).unwrap();
-            assert_eq!(expected_len, out_buffer.len());
-            return out_buffer;
-        } else {
-            let out_buffer = __inflate::inflate_bytes(&in_buffer[2..]).unwrap();
-            return out_buffer;
-        }
+    pub fn unzip(in_buffer : &[u8]) -> Vec<u8>{
+        assert_eq!(in_buffer[0..2],[0x11, 0x72], "in_buffer does not have bk header");
+        let expected_len = u32::from_be_bytes(in_buffer[2..6].try_into().unwrap()) as usize;
+        let out_buffer = __inflate::inflate_bytes(&in_buffer[6..]).unwrap();
+        assert_eq!(expected_len, out_buffer.len());
+        return out_buffer;
+
         // let mut out_buffer: Vec<u8> = vec![0; expected_len];
         // let out_len = unsafe{__rarezip::bk_unzip(in_buffer.as_ptr(), in_buffer.len(), out_buffer.as_mut_ptr(), out_buffer.len())};
         // assert_eq!(expected_len, out_len, "out size does not match expected size");
         // return out_buffer;
+    }
+}
+
+pub mod bt{
+    use inflate as __inflate;
+    use super::__rarezip;
+    use super::MAX_MATCH;
+
+    pub fn zip(in_buffer : &[u8]) -> Vec<u8>{
+        let mut out_buffer: Vec<u8> = vec![0; in_buffer.len() + MAX_MATCH];
+        let out_length = unsafe{__rarezip::bk_zip(in_buffer.as_ptr(), in_buffer.len(), out_buffer.as_mut_ptr(), out_buffer.len())};
+        out_buffer.resize(out_length, 0);
+        // out_buffer.resize((out_buffer.len() + (8-1)) & !(8-1), 0xAA);
+        return out_buffer
+    }
+
+    pub fn unzip(in_buffer : &[u8]) -> Vec<u8>{
+            let expected_len = (u16::from_be_bytes([in_buffer[0], in_buffer[1]]) as usize) * 0x10; 
+            let out_buffer = __inflate::inflate_bytes(&in_buffer[2..]).unwrap();
+            //assert_eq!(expected_len, out_buffer.len(), "out size does not match expected size"); 
+            return out_buffer;
     }
 }
 

--- a/rust/src/rarezip.rs
+++ b/rust/src/rarezip.rs
@@ -60,12 +60,17 @@ pub mod bk{
         return out_buffer
     }
 
-    pub fn unzip(in_buffer : &[u8]) -> Vec<u8>{
-        assert_eq!(in_buffer[0..2],[0x11, 0x72], "in_buffer does not have bk header");
-        let expected_len = u32::from_be_bytes(in_buffer[2..6].try_into().unwrap()) as usize;
-        let out_buffer = __inflate::inflate_bytes(&in_buffer[6..]).unwrap();
-        assert_eq!(expected_len, out_buffer.len());
-        return out_buffer;
+    pub fn unzip(in_buffer : &[u8], full_header: bool) -> Vec<u8>{
+        if full_header {
+            assert_eq!(in_buffer[0..2],[0x11, 0x72], "in_buffer does not have bk header");
+            let expected_len = u32::from_be_bytes(in_buffer[2..6].try_into().unwrap()) as usize;
+            let out_buffer = __inflate::inflate_bytes(&in_buffer[6..]).unwrap();
+            assert_eq!(expected_len, out_buffer.len());
+            return out_buffer;
+        } else {
+            let out_buffer = __inflate::inflate_bytes(&in_buffer[2..]).unwrap();
+            return out_buffer;
+        }
         // let mut out_buffer: Vec<u8> = vec![0; expected_len];
         // let out_len = unsafe{__rarezip::bk_unzip(in_buffer.as_ptr(), in_buffer.len(), out_buffer.as_mut_ptr(), out_buffer.len())};
         // assert_eq!(expected_len, out_len, "out size does not match expected size");


### PR DESCRIPTION
Adds bt_zip and bt_unzip that handle compression and decompression with the Banjo-Tooie compressed data header and set the correct compression level.